### PR TITLE
#5 adding SCC support

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -41,3 +41,7 @@ Initial version
 
 - #2 Adding support for SharePoint Online service (SPO)
 - Adding generated psm1 docs to docs dir in src
+
+## v0.0.6
+
+- #5 Adding support for Office365 Security & Compliance Center

--- a/docs/02-USAGE.md
+++ b/docs/02-USAGE.md
@@ -34,6 +34,12 @@ The service you want to connect is selected by `-Service` parameter, followed by
 
   See the [CmdLet reference](https://docs.microsoft.com/en-us/powershell/module/sharepoint-online/) for all available commands.
 
+* __SCC__ - Office365 Security & Compliance Center
+
+  Uses [ExchangeOnlineManagement](https://docs.microsoft.com/powershell/exchange/exchange-online/exchange-online-powershell-v2/exchange-online-powershell-v2) (Exchange Online PowerShell v2) module to connect to Office365 Security & Compliance Center.
+
+  _Old plain Remote PowerShell connections are not supported anymore! Please see the documentation for the new CmdLets available._
+
 ### Multi Factor Authentication (MFA)
 
 If you have to use MFA you may get errors when connection with standard options. Add `-MFA` switch to your Connect-MS365 command.

--- a/docs/Connect-MS365.md
+++ b/docs/Connect-MS365.md
@@ -35,6 +35,7 @@ Supports connection handling for
 - Exchange Online (EOL)
 - Teams
 - SharePoint Online (SPO)
+- Security and Compliance Center (SCC)
 
 ## EXAMPLES
 
@@ -72,6 +73,13 @@ Description: Connect to SharePoint Online with MFA to connect to MyName-admin.sh
 ```
 
 Connect-MS365 -Service SPO -SPOOrgName MyName -MFA
+
+### EXAMPLE 6
+```
+Description: Connect to Security and Compliance Center with MFA
+```
+
+Connect-MS365 -Service SCC -MFA
 
 ## PARAMETERS
 

--- a/src/Connect-MS365.psd1
+++ b/src/Connect-MS365.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Connect-MS365.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.5'
+ModuleVersion = '0.0.6'
 
 # Supported PSEditions
 CompatiblePSEditions = @('PSEdition_Desktop','Desktop')
@@ -102,6 +102,7 @@ PrivateData = @{
             'Exchange_Online','ExchangeOnline','EOL',
             'Microsoft_Teams','Teams',
             'Skype_for_Business','SfB','S4B','Skype4B',
+            'SecurityComplianceCenter','IPP','SCC',
             'Azure','Microsoft_Azure','AzureAD','Azure_AD','AAD')
 
         # A URL to the license for this module.

--- a/src/Connect-MS365.psm1
+++ b/src/Connect-MS365.psm1
@@ -9,6 +9,7 @@ One or multiple service names can be chosen. Supports connection handling for
 - Exchange Online (EOL)
 - Teams
 - SharePoint Online (SPO)
+- Security and Compliance Center (SCC)
 
 .PARAMETER Service
 Specifies the service to connect to. May be a list of multiple services to use.
@@ -42,6 +43,10 @@ Connect-MS365 -Service SPO -SPOOrgName MyName
 Description: Connect to SharePoint Online with MFA to connect to MyName-admin.sharepoint.com 
 Connect-MS365 -Service SPO -SPOOrgName MyName -MFA
 
+.EXAMPLE
+Description: Connect to Security and Compliance Center with MFA  
+Connect-MS365 -Service SCC -MFA
+
 .LINK
 https://github.com/blindzero/Connect-MS365
 
@@ -54,7 +59,7 @@ function Connect-MS365 {
         #service parameter to define to which services to connect to
         #are validated against available / implemented services
         [Parameter(Mandatory=$True, Position = 1)]
-        [ValidateSet('MSOL','EOL','Teams','SPO')]
+        [ValidateSet('MSOL','EOL','Teams','SPO','SCC')]
         [string]
         $Service,
         #spoorg parameter for connection to SPO service
@@ -113,6 +118,16 @@ function Connect-MS365 {
                 }
                 else {
                     Connect-Teams -Credential $Credential
+                }
+                continue
+            }
+            # Security and Compliance Center
+            SCC {
+                if ($MFA) {
+                    Connect-SCC
+                }
+                else {
+                    Connect-SCC -Credential $Credential
                 }
                 continue
             }

--- a/src/Private/Install-MS365Module.ps1
+++ b/src/Private/Install-MS365Module.ps1
@@ -3,7 +3,7 @@ function Install-MS365Module {
     param (
         # service module to be installed, must be known service
         [Parameter(Mandatory=$True,Position=1)]
-        [ValidateSet('MSOL','EOL','Teams','SPO')]
+        [ValidateSet('MSOL','EOL','Teams','SPO','SCC')]
         [String]
         $Service
     )
@@ -43,7 +43,7 @@ function Install-MS365Module {
         MSOL {
             $ModuleName = "MSOnline"
         }
-        EOL {
+        {($_ -eq "EOL") -or ($_ -eq "SCC")} {
             $ModuleName = "ExchangeOnlineManagement"
         }
         Teams {

--- a/src/Private/Test-MS365Module.ps1
+++ b/src/Private/Test-MS365Module.ps1
@@ -3,7 +3,7 @@ function Test-MS365Module {
     param (
         # service module to be tested, must be known service
         [Parameter(Mandatory=$True,Position=1)]
-        [ValidateSet('MSOL','EOL','Teams','SPO')]
+        [ValidateSet('MSOL','EOL','Teams','SPO','SCC')]
         [String]
         $Service
     )
@@ -57,8 +57,8 @@ function Test-MS365Module {
                 $True
             }
         }
-        # Exchange Online Service
-        EOL {
+        # Exchange Online Service or Security Compliance Center
+        {($_ -eq "EOL") -or ($_ -eq "SCC")} {
             If ($null -eq (Get-Module @GetModulesSplat -Name "ExchangeOnlineManagement")) {
                 $False
             }

--- a/src/Public/Connect-SCC.ps1
+++ b/src/Public/Connect-SCC.ps1
@@ -1,0 +1,62 @@
+function Connect-SCC {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$False,Position=1)]
+        [PSCredential]
+        $Credential
+    )
+
+    <#
+    .SYNOPSIS
+
+    Connects to Microsoft Security and Comliance Center.
+
+    .DESCRIPTION
+
+    Connects to Microsoft Security and Comliance Center.
+
+    .PARAMETER Credential
+
+    PSCredential object containing user credentials.
+
+    .INPUTS
+
+    None. You cannot pipe objects to Add-Extension.
+
+    .OUTPUTS
+
+    // <OBJECTTYPE>. TBD.
+
+    .EXAMPLE
+
+    PS> Connect-SCC -Credential $Credential
+
+    .LINK
+
+    http://github.com/blindzero/Connect-MS365
+
+    #>
+
+    # testing if module is available
+    while (!(Test-MS365Module -Service $ServiceItem)) {
+        # and install if not available
+        Install-MS365Module -Service $ServiceItem
+    }
+    try {
+        # if MFA is set connect without PScredential object as modern authentication will be used
+        if ($MFA) {
+            Connect-IPPSSession
+        }
+        # or pass PSCredential object it will asked if not created earlier
+        else {
+            Connect-IPPSSession -Credential $Credential
+        }
+    }
+    catch {
+        $ErrorMessage = $_.Exception.Message
+        Write-Error -Message "Could not connect to $ServiceItem.`n$ErrorMessage" -Category ConnectionError
+        Break
+    }
+    # set service name into window title if successfully connected
+    Set-WindowTitle -Service $ServiceItem
+}

--- a/tests/Connect-MS365.Tests.ps1
+++ b/tests/Connect-MS365.Tests.ps1
@@ -61,6 +61,7 @@ Describe "Function Tests" -Tags ('Unit') {
         { Get-Command Connect-MSOL } | Should Throw
         { Get-Command Connect-Teams } | Should Throw
         { Get-Command Connect-SPO } | Should Throw
+        { Get-Command Connect-SCC } | Should Throw
         { Get-Command Test-MS365Module } | Should Throw
         { Get-Command Install-MS365Module } | Should Throw
         { Get-Command Set-WindowTitle } | Should Throw
@@ -91,6 +92,12 @@ Describe "Function Tests" -Tags ('Unit') {
             It "Has Parameter -SPOOrgName" {
                 Get-Command Connect-SPO | Should -HaveParameter SPOOrgUrl -Type String
                 Get-Command Connect-SPO | Should -HaveParameter SPOOrgUrl -Mandatory
+            }
+        }
+        Context "Function Connect-SCC.ps1 Tests" {
+            It "Has Parameter -Credential" {
+                Get-Command Connect-Teams | Should -HaveParameter Credential -Type PSCredential
+                Get-Command Connect-Teams | Should -HaveParameter Credential -Not -Mandatory
             }
         }
         Context "Function Set-WindowTitle.ps1 Tests" {


### PR DESCRIPTION
## Adding support for Office365 Security and Compliance Center

* SCC connection handler Script Connect-SCC.ps1 added
* Manifest: version 0.0.6 set and added Tags for SCC
* Updated RELEASENOTES, README / USAGE
* added SCC test switch case for Test- and Install-Module script on `ExchangeOnlineManagement` module
* invoking SCC connection handler from module