### PR TITLE
#15 adding module updater function in Test-MS365Module

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -14,6 +14,9 @@ Powershell module to connect to all MS365 services and install required packages
 
 ### New
 
+- [#15 Module Updater](https://github.com/blindzero/Connect-MS365/issues/15)
+  Comparing installed and available module version and prompt to update.
+
 ### Fixes
 
 ## v1.0.0

--- a/docs/02-USAGE.md
+++ b/docs/02-USAGE.md
@@ -58,6 +58,10 @@ If you have to use MFA you may get errors when connection with standard options.
 
 When connecting the necessary module is checked and can be installed autoamtically if not available. No manual installation of modules...yah!
 
+### Module Updates
+
+For each module invocation the online available version is checked. If a newer version is available, user is prompted for (optional) update.
+
 ### Details
 
 For further details see [Connect-MS365.md](Connect-MS365.md)

--- a/docs/Connect-MS365.md
+++ b/docs/Connect-MS365.md
@@ -14,17 +14,18 @@ Connects to a given online service of Microsoft.
 
 ### True (Default)
 ```
-Connect-MS365 [-Service] <String> [[-SPOOrgName] <String>] [<CommonParameters>]
+Connect-MS365 [-Service] <String[]> [[-SPOOrgName] <String>] [<CommonParameters>]
 ```
 
 ### MFA
 ```
-Connect-MS365 [-Service] <String> [[-SPOOrgName] <String>] [-MFA] [<CommonParameters>]
+Connect-MS365 [-Service] <String[]> [[-SPOOrgName] <String>] [-MFA] [<CommonParameters>]
 ```
 
 ### Credential
 ```
-Connect-MS365 [-Service] <String> [[-SPOOrgName] <String>] [[-Credential] <PSCredential>] [<CommonParameters>]
+Connect-MS365 [-Service] <String[]> [[-SPOOrgName] <String>] [[-Credential] <PSCredential>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -96,7 +97,7 @@ Specifies the service to connect to.
 May be a list of multiple services to use.
 
 ```yaml
-Type: String
+Type: String[]
 Parameter Sets: (All)
 Aliases:
 

--- a/src/Connect-MS365.psd1
+++ b/src/Connect-MS365.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Connect-MS365.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.0'
+ModuleVersion = '1.1.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('PSEdition_Desktop','Desktop')

--- a/src/Connect-MS365.psm1
+++ b/src/Connect-MS365.psm1
@@ -91,6 +91,8 @@ function Connect-MS365 {
         $Credential = Get-Credential -Message "Please enter your Office 365 credentials"
     }
     
+    # TODO #10: changing to settings array containing module names making switch unnecessary
+
     # iterating through each service listed in service parameter
     # each service is passing PSCredential object if MFA not set or leaves it out if set
     ForEach ($ServiceItem in $Service) {
@@ -98,6 +100,9 @@ function Connect-MS365 {
         Switch($ServiceItem) {
             # Microsoft Online service
             MSOL {
+                $ServiceName = "Microsoft Online / AzureAD v1"
+                $ModuleName = "MSOnline"
+
                 if ($MFA) {
                     Connect-MSOL
                 }
@@ -108,6 +113,9 @@ function Connect-MS365 {
             }
             # Exchange Online service
             EOL {
+                $ServiceName = "Exchange Online"
+                $ModuleName = "ExchangeOnlineManagement"
+
                 if ($MFA) {
                     Connect-EOL
                 }
@@ -118,6 +126,9 @@ function Connect-MS365 {
             }
             # Teams service
             Teams {
+                $ServiceName = "Microsoft Teams"
+                $ModuleName = "MicrosoftTeams"
+
                 if ($MFA) {
                     Connect-Teams
                 }
@@ -128,6 +139,9 @@ function Connect-MS365 {
             }
             # Security and Compliance Center
             SCC {
+                $ServiceName = "Security & Compliance Center"
+                $ModuleName = "ExchangeOnlineManagement"
+
                 if ($MFA) {
                     Connect-SCC
                 }
@@ -138,6 +152,9 @@ function Connect-MS365 {
             }
             # AzureAD
             AAD {
+                $ServiceName = "AzureAD v2"
+                $ModuleName = "AzureAD"
+
                 if ($MFA) {
                     Connect-AAD
                 }
@@ -148,6 +165,9 @@ function Connect-MS365 {
             }
             # SPO service
             SPO {
+                $ServiceName = "SharePoint Online"
+                $ModuleName = "Microsoft.Online.SharePoint.PowerShell"
+
                 If (!($SPOOrgName)) {
                     Write-Error 'To connect to SharePoint Online you have to provide the -SPOOrgName parameter.'
                     continue

--- a/src/Private/Install-MS365Module.ps1
+++ b/src/Private/Install-MS365Module.ps1
@@ -3,63 +3,38 @@ function Install-MS365Module {
     param (
         # service module to be installed, must be known service
         [Parameter(Mandatory=$True,Position=1)]
-        [ValidateSet('MSOL','EOL','Teams','SPO','SCC','AAD')]
         [String]
-        $Service
+        $Module
     )
 
     <#
     .SYNOPSIS
-
     Installs modules to connect for a given service.
 
     .DESCRIPTION
-
     Installs modules to connect for a given service.
-    Service name needs to be passed.
+    ModuleName name needs to be passed.
 
-    .PARAMETER Service
-    Name of service to check installed modules for.
+    .PARAMETER Module
+    Name of powershell module to install.
 
     .INPUTS
-
     None. You cannot pipe objects to Add-Extension.
 
     .OUTPUTS
-
     // <OBJECTTYPE>. TBD.
 
     .EXAMPLE
-
-    Install-MS365Module -Service MSOL
+    Install-MS365Module -Module MSOnline
 
     .LINK
-
     http://github.com/blindzero/Connect-MS365
 
     #>
 
-    switch($Service) {
-        MSOL {
-            $ModuleName = "MSOnline"
-        }
-        {($_ -eq "EOL") -or ($_ -eq "SCC")} {
-            $ModuleName = "ExchangeOnlineManagement"
-        }
-        Teams {
-            $ModuleName = "MicrosoftTeams"
-        }
-        SPO {
-            $ModuleName = "Microsoft.Online.SharePoint.PowerShell"
-        }
-        AAD {
-            $ModuleName = "AzureAD"
-        }
-    }
-
-    $InstallCommand = "-Command &{ Install-Module -Name $ModuleName -Scope AllUsers }"
-    $InstallChoice = Read-Host -Prompt "$ModuleName Module is not present! Install it (Y/n)"
-    If (($InstallChoice -eq "") -or ($InstallChoice -eq "y") -or ($InstallChoice -eq "Y")) {
+    $InstallCommand = "-Command &{ Install-Module -Name $Module -Scope AllUsers -Force}"
+    $InstallChoice = Read-Host -Prompt "Module $Module is not present or update was triggered. Perform Install? (Y/n)"
+    If (($InstallChoice.Length -eq 0) -or ($InstallChoice.ToLower() -eq "y")) {
         try {
             Start-Process -Filepath powershell -ArgumentList $InstallCommand -Verb RunAs -Wait
         }

--- a/src/Public/Connect-AAD.ps1
+++ b/src/Public/Connect-AAD.ps1
@@ -8,37 +8,30 @@ function Connect-AAD {
 
     <#
     .SYNOPSIS
-
     Connects to Microsoft Azure ActiveDirectory (AzureAD / AAD) service.
 
     .DESCRIPTION
-
     Connects to Microsoft Azure ActiveDirectory (AzureAD / AAD) service.
 
     .PARAMETER Credential
-
     PSCredential object containing user credentials.
 
     .INPUTS
-
     None. You cannot pipe objects to Add-Extension.
 
     .OUTPUTS
-
     // <OBJECTTYPE>. TBD.
 
     .EXAMPLE
-
     PS> Connect-AAD -Credential $Credential
 
     .LINK
-
     http://github.com/blindzero/Connect-MS365
 
     #>
 
     # testing if module is available
-    while (!(Test-MS365Module -Service $ServiceItem)) {
+    while (!(Test-MS365Module -Module $ModuleName)) {
         # and install if not available
         Install-MS365Module -Service $ServiceItem
     }

--- a/src/Public/Connect-EOL.ps1
+++ b/src/Public/Connect-EOL.ps1
@@ -38,9 +38,9 @@ function Connect-EOL {
     #>
 
     # testing if module is available
-    while (!(Test-MS365Module -Service $ServiceItem)) {
+    while (!(Test-MS365Module -Module $ModuleName)) {
         # and install if not available
-        Install-MS365Module -Service $ServiceItem
+        Install-MS365Module -Module $ModuleName
     }
     try {
         # if MFA is set connect without PScredential object as modern authentication will be used

--- a/src/Public/Connect-MSOL.ps1
+++ b/src/Public/Connect-MSOL.ps1
@@ -8,39 +8,32 @@ function Connect-MSOL {
 
     <#
     .SYNOPSIS
-
     Connects to Microsoft Online service.
 
     .DESCRIPTION
-
-    Connects to Microsoft Online service.
+    Connects to Microsoft Online service / Azure ActiveDirectory v1
 
     .PARAMETER Credential
-
     PSCredential object containing user credentials.
 
     .INPUTS
-
     None. You cannot pipe objects to Add-Extension.
 
     .OUTPUTS
-
     // <OBJECTTYPE>. TBD.
 
     .EXAMPLE
-
     PS> Connect-MSOL -Credential $Credential
 
     .LINK
-
     http://github.com/blindzero/Connect-MS365
 
     #>
 
     # testing if module is available
-    while (!(Test-MS365Module -Service $ServiceItem)) {
+    while (!(Test-MS365Module -Module $ModuleName)) {
         # and install if not available
-        Install-MS365Module -Service $ServiceItem
+        Install-MS365Module -Module $ModuleName
     }
     try {
         # if MFA is set connect without PScredential object as modern authentication will be used

--- a/src/Public/Connect-SCC.ps1
+++ b/src/Public/Connect-SCC.ps1
@@ -8,39 +8,32 @@ function Connect-SCC {
 
     <#
     .SYNOPSIS
-
     Connects to Microsoft Security and Comliance Center.
 
     .DESCRIPTION
-
     Connects to Microsoft Security and Comliance Center.
 
     .PARAMETER Credential
-
     PSCredential object containing user credentials.
 
     .INPUTS
-
     None. You cannot pipe objects to Add-Extension.
 
     .OUTPUTS
-
     // <OBJECTTYPE>. TBD.
 
     .EXAMPLE
-
     PS> Connect-SCC -Credential $Credential
 
     .LINK
-
     http://github.com/blindzero/Connect-MS365
 
     #>
 
     # testing if module is available
-    while (!(Test-MS365Module -Service $ServiceItem)) {
+    while (!(Test-MS365Module -Module $ModuleName)) {
         # and install if not available
-        Install-MS365Module -Service $ServiceItem
+        Install-MS365Module -Module $ModuleName
     }
     try {
         # if MFA is set connect without PScredential object as modern authentication will be used

--- a/src/Public/Connect-SPO.ps1
+++ b/src/Public/Connect-SPO.ps1
@@ -43,9 +43,9 @@ function Connect-SPO {
     #>
 
     # testing if module is available
-    while (!(Test-MS365Module -Service $ServiceItem)) {
+    while (!(Test-MS365Module -Module $ModuleName)) {
         # and install if not available
-        Install-MS365Module -Service $ServiceItem
+        Install-MS365Module -Module $ModuleName
     }
     try {
         # if MFA is set connect without PScredential object as modern authentication will be used

--- a/src/Public/Connect-Teams.ps1
+++ b/src/Public/Connect-Teams.ps1
@@ -38,9 +38,9 @@ function Connect-Teams {
     #>
 
     # testing if module is available
-    while (!(Test-MS365Module -Service $ServiceItem)) {
+    while (!(Test-MS365Module -Module $ModuleName)) {
         # and install if not available
-        Install-MS365Module -Service $ServiceItem
+        Install-MS365Module -Module $ModuleName
     }
     try {
         # if MFA is set connect without PScredential object as modern authentication will be used


### PR DESCRIPTION
* moved $ModuleName switch case out of install- and test-ms365module to main module
* changing param -Service to -Module for install- and test-ms365module, expecting complete module name instead of self-defining as might be inconsistent in both functions
* adding module version comparision in test-ms365module with return $false to trigger install (which is optional)