### PR TITLE
#33 Adding support for PowerShell 7 / PowerShell core

### DIFF
--- a/.github/workflows/master-compile.yml
+++ b/.github/workflows/master-compile.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     strategy:
       matrix:
-        psversion: [5]
+        psversion: [5,7]
         os: [windows-latest]
     permissions:
       contents: read # for actions/checkout to fetch code

--- a/.github/workflows/master-compile.yml
+++ b/.github/workflows/master-compile.yml
@@ -67,12 +67,11 @@ jobs:
         run: |
           $VerbosePreference = "Continue"
           .\build.ps1 PesterUnit
-      - name: Upload Pester Test Results
+      - name: Upload Pester Unit Test Results
         uses: actions/upload-artifact@v3
         with:
           name: windows-Unit-Tests
           path: .\BuildOutput\testResultsUnit.xml
-        if: ${{ always() }}
       - name: Create Help Files
         shell: powershell
         run: |
@@ -82,17 +81,13 @@ jobs:
       - name: Build Package
         shell: powershell
         run: .\build.ps1 Build
-      - name: Build Package
-        shell: powershell
-        run: .\build.ps1 Build
       - name: Pester Integration
         shell: powershell
         run: |
           $VerbosePreference = "Continue"
           .\build.ps1 PesterIntegration
-      - name: Upload Pester Test Results
+      - name: Upload Pester Integration Test Results
         uses: actions/upload-artifact@v3
         with:
           name: windows-Integration-Tests
           path: .\BuildOutput\testResultsIntegration.xml
-        if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/blindzero/Connect-MS365)
 
 # Connect-MS365
+
 Powershell module to connect to all MS365 services and install required modules or packages.
 
 ## Purpose
@@ -22,6 +23,15 @@ Additionally it checks and installs the right modules or packages if necessary.
 It is inspired by Connect-Office365 by [Bradley Wyatt](https://github.com/bwya77) which I found and used for a while.
 As it wasn't published it was something I had to keep and distribute again and again.
 Additionally I wanted to add some advanced functions like installing and updating the dependant Microsoft modules.
+
+## Limitations
+
+Unfortunately, adding PowerShell Core support (a.k.a. PowerShell 7) brought some limitations for supported Microsoft 365 services as the required modules do not support PowerShell Core. 
+Following Microsoft 365 services are _**NOT**_ supported when using PowerShell 7 / PowerShell core:
+
+* SharePoint Online (SPO)
+* Microsoft Online (MSOL)
+* Microsoft Azure AD (AAD)
 
 ## Documentation
 
@@ -52,6 +62,7 @@ I use the following toolstake to develop and distribute this module:
 For further details please see [03-CONTRIBUTE](/docs/03-CONTRIBUTE.md)
 
 ### Maintainer
+
 * [blindzero](https://github.com/blindzero)
 * ...anybody else?
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -11,7 +11,15 @@ Powershell module to connect to all MS365 services and install required packages
 - [#9](https://github.com/blindzero/Connect-MS365/issues/9) Proxy Support
 - [#21](https://github.com/blindzero/Connect-MS365/issues/21) CSP connections support
 - [#23](https://github.com/blindzero/Connect-MS365/issues/23) user config files
-- adding PSDeply for Github and PSGallery release
+- adding PSDeploy for Github and PSGallery release
+
+## v2.0.0
+
+### New Features
+
+- adding support for PSCore edition to support PowerShell 7
+  - removing support for service MSOL, AAD, SPO
+- removed support for S4B (Skype4Business)
 
 ## v1.3.0
 
@@ -36,3 +44,87 @@ Powershell module to connect to all MS365 services and install required packages
 ### Fixes
 
 - Fix AAD module installer
+
+## v1.2.0
+
+### New Features
+
+- [#24](https://github.com/blindzero/Connect-MS365/issues/24) added Skype for Business option
+
+### Changes
+
+- re-enabling code notary git signature check
+
+### Fixes
+
+## v1.1.0
+
+### New
+
+- [#15 Module Updater](https://github.com/blindzero/Connect-MS365/issues/15)
+  Comparing installed and available module version and prompt to update.
+- [#7 Support MS Azure](https://github.com/blindzero/Connect-MS365/issues/7)
+  Uses Az module and Connect-AzAccount
+
+### Changes
+
+- Removed -MFA switch and Credential passing
+
+### Fixes
+
+- [#18 Service parameter not accepting multiple services](https://github.com/blindzero/Connect-MS365/issues/18)
+
+## v1.0.0
+
+### New
+
+All features from pre-release versions:
+
+- #5 Adding support for Office365 Security & Compliance Center
+- #6 Adding support for Azure ActiveDirectory (AzureAD, AAD) v2
+- #2 Adding support for SharePoint Online service (SPO)
+- Adding generated psm1 docs to docs dir in src
+- #1 Adding support for MS Exchange Online service (EOL)
+- Adding support for Microsoft Online service (MSOL) a.k.a. AzureAD v1
+- Installs MSOnline module if not available
+
+### Fix
+
+- correction SCC function unit test to SCC script (calles wrong script for test)
+- Manifest tags compatible for powershellgallery.com upload by removing spaces
+- removing Umlauts
+
+## v0.0.6
+
+### New
+
+- #5 Adding support for Office365 Security & Compliance Center
+- #6 Adding support for Azure ActiveDirectory (AzureAD, AAD) v2
+
+### Fix
+
+- correction SCC function unit test to SCC script (calles wrong script for test)
+
+## v0.0.5
+
+- #2 Adding support for SharePoint Online service (SPO)
+- Adding generated psm1 docs to docs dir in src
+
+## v0.0.4
+
+- #3 Adding support for MS Teams service (Teams)
+- Adding additional docs for Installation and Usage
+
+## v0.0.3
+
+- #1 Adding support for MS Exchange Online service (EOL)
+
+## v0.0.2
+
+- Manifest tags compatible for powershellgallery.com upload by removing spaces
+- removing Umlauts
+
+## v0.0.1
+
+- Adding support for Microsoft Online service (MSOL) a.k.a. AzureAD v1
+- Installs MSOnline module if not available

--- a/build/dependencies.psd1
+++ b/build/dependencies.psd1
@@ -4,10 +4,10 @@
     }
 
     BuildHelpers        = 'latest'
-    Pester              = '5.0.1'
+    Pester              = '5.4.1'
     platyPS             = 'latest'
     psake               = 'latest'
     PSScriptAnalyzer    = 'latest'
     NuGet               = 'latest'
-    PowerShellGet       = '2.2.4.1'
+    PowerShellGet       = '2.2.5'
 }

--- a/docs/00-RELEASENOTES.md
+++ b/docs/00-RELEASENOTES.md
@@ -11,7 +11,15 @@ Powershell module to connect to all MS365 services and install required packages
 - [#9](https://github.com/blindzero/Connect-MS365/issues/9) Proxy Support
 - [#21](https://github.com/blindzero/Connect-MS365/issues/21) CSP connections support
 - [#23](https://github.com/blindzero/Connect-MS365/issues/23) user config files
-- adding PSDeply for Github and PSGallery release
+- adding PSDeploy for Github and PSGallery release
+
+## v2.0.0
+
+### New Features
+
+- adding support for PSCore edition to support PowerShell 7
+  - removing support for service MSOL, AAD, SPO
+- removed support for S4B (Skype4Business)
 
 ## v1.3.0
 

--- a/docs/01-INSTALLATION.md
+++ b/docs/01-INSTALLATION.md
@@ -6,12 +6,15 @@
 
 The following requirements must be installed _prior_ installation of Connect-MS365.
 
-* [PowerShell v5.1](https://www.microsoft.com/en-us/download/details.aspx?id=54616)
+* [PowerShell v5.1](https://www.microsoft.com/en-us/download/details.aspx?id=54616) or
+  [PowerShell v7.3.4](https://github.com/PowerShell/powershell/releases)
 
   Check your PS version with `$PSVersionTable`.
   We need at least Version 5.1 on Desktop edition.
+  Core edition is tested with PowerShell 7.3.4, but may work with earlier versions as well.
 
-* [PowerShellGet]() (should be available automatically)
+* [PowerShellGet](https://learn.microsoft.com/en-us/powershell/gallery/powershellget/overview)
+  (should be available automatically)
 
   Check if available with
   
@@ -24,6 +27,11 @@ The following requirements must be installed _prior_ installation of Connect-MS3
   ```powershell
   Install-Module -Name PowerShellGet -Force
   ```
+
+* [ExchangeOnlineManagement Module v3](https://www.powershellgallery.com/packages/ExchangeOnlineManagement) - if used with PS Core 7
+
+  It is recommended to use EXOv3 module with PowerShell 7 as authentication issues may occure if older EXO modules are used.
+  If you face any issue that authentication libraries cannot be loaded, make sure that EXOv3 is installed and available for `Connect-MS365`.
 
 ### Installation
 

--- a/docs/01-INSTALLATION.md
+++ b/docs/01-INSTALLATION.md
@@ -50,7 +50,7 @@ With this method you may install Connect-MS365 manually to your PowerShell envir
 1. __Download Connect-MS365__ from one of the following sources
 
    * [PowerShellGallery Package](https://www.powershellgallery.com/packages/Connect-MS365#manual-download)
-   
+
    * [GitHub](https://github.com/blindzero/Connect-MS365/releases)
 
 2. __Extract Package__ by unzipping the downloaded package.

--- a/docs/Connect-MS365.md
+++ b/docs/Connect-MS365.md
@@ -8,38 +8,32 @@ schema: 2.0.0
 # Connect-MS365
 
 ## SYNOPSIS
-
 {{ Fill in the Synopsis }}
 
 ## SYNTAX
 
 ### True (Default)
-
-```powershell
+```
 Connect-MS365 [-Service] <String[]> [[-SPOOrgName] <String>] [<CommonParameters>]
 ```
 
 ### Credential
-
-```powershell
+```
 Connect-MS365 [-Service] <String[]> [[-SPOOrgName] <String>] [[-Credential] <PSCredential>]
  [<CommonParameters>]
 ```
 
 ### ReInitConfig
-
-```powershell
+```
 Connect-MS365 [-Service] <String[]> [[-SPOOrgName] <String>] [-ReInitConfig] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-
 {{ Fill in the Description }}
 
 ## EXAMPLES
 
 ### Example 1
-
 ```powershell
 PS C:\> {{ Add example code here }}
 ```
@@ -49,7 +43,6 @@ PS C:\> {{ Add example code here }}
 ## PARAMETERS
 
 ### -Credential
-
 {{ Fill Credential Description }}
 
 ```yaml
@@ -65,7 +58,6 @@ Accept wildcard characters: False
 ```
 
 ### -ReInitConfig
-
 {{ Fill ReInitConfig Description }}
 
 ```yaml
@@ -81,7 +73,6 @@ Accept wildcard characters: False
 ```
 
 ### -SPOOrgName
-
 {{ Fill SPOOrgName Description }}
 
 ```yaml
@@ -97,7 +88,6 @@ Accept wildcard characters: False
 ```
 
 ### -Service
-
 {{ Fill Service Description }}
 
 ```yaml
@@ -114,7 +104,6 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -124,7 +113,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### System.Object
-
 ## NOTES
 
 ## RELATED LINKS

--- a/docs/Connect-MS365.md
+++ b/docs/Connect-MS365.md
@@ -8,32 +8,38 @@ schema: 2.0.0
 # Connect-MS365
 
 ## SYNOPSIS
+
 {{ Fill in the Synopsis }}
 
 ## SYNTAX
 
 ### True (Default)
-```
+
+```powershell
 Connect-MS365 [-Service] <String[]> [[-SPOOrgName] <String>] [<CommonParameters>]
 ```
 
 ### Credential
-```
+
+```powershell
 Connect-MS365 [-Service] <String[]> [[-SPOOrgName] <String>] [[-Credential] <PSCredential>]
  [<CommonParameters>]
 ```
 
 ### ReInitConfig
-```
+
+```powershell
 Connect-MS365 [-Service] <String[]> [[-SPOOrgName] <String>] [-ReInitConfig] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
+
 {{ Fill in the Description }}
 
 ## EXAMPLES
 
 ### Example 1
+
 ```powershell
 PS C:\> {{ Add example code here }}
 ```
@@ -58,6 +64,7 @@ Accept wildcard characters: False
 ```
 
 ### -ReInitConfig
+
 {{ Fill ReInitConfig Description }}
 
 ```yaml
@@ -73,6 +80,7 @@ Accept wildcard characters: False
 ```
 
 ### -SPOOrgName
+
 {{ Fill SPOOrgName Description }}
 
 ```yaml
@@ -88,6 +96,7 @@ Accept wildcard characters: False
 ```
 
 ### -Service
+
 {{ Fill Service Description }}
 
 ```yaml
@@ -104,15 +113,17 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
-### Keine
+### None
 
 ## OUTPUTS
 
 ### System.Object
+
 ## NOTES
 
 ## RELATED LINKS

--- a/docs/Connect-MS365.md
+++ b/docs/Connect-MS365.md
@@ -49,6 +49,7 @@ PS C:\> {{ Add example code here }}
 ## PARAMETERS
 
 ### -Credential
+
 {{ Fill Credential Description }}
 
 ```yaml

--- a/src/Connect-MS365.psd1
+++ b/src/Connect-MS365.psd1
@@ -15,7 +15,7 @@ RootModule = 'Connect-MS365.psm1'
 ModuleVersion = '1.3.0'
 
 # Supported PSEditions
-CompatiblePSEditions = @('PSEdition_Desktop','Desktop')
+CompatiblePSEditions = @('PSEdition_Desktop','Desktop','PSEdition_Core','Core')
 
 # ID used to uniquely identify this module
 GUID = '57ba2e99-b943-4f13-86a6-adca8db16f93'
@@ -97,7 +97,8 @@ PrivateData = @{
 
         # Tags applied to this module. These help with module discovery in online galleries.
         Tags = @(
-            'PSEdition_Desktop','Windows',
+            'PSEdition_Desktop','Desktop','Windows',
+            'PSEdition_Core','Core','Linux','MacOS'
             'Microsoft_365','MS_365','Microsoft365','MS365',
             'O365','Office_365','Office365','Microsoft_Online','MSOL',
             'Exchange_Online','ExchangeOnline','EOL',

--- a/src/Private/Initialize-Config.ps1
+++ b/src/Private/Initialize-Config.ps1
@@ -52,8 +52,8 @@ function Initialize-Config {
     # if we want to enforce new file OR the file is not existing
     if (($Force) -or (!(Get-Item -Path $ConfigPath -ErrorAction SilentlyContinue))) {
         # we place the default file in our config dir
+        Write-Verbose "Initializing config file from $DefaultConfigFilePath to $ConfigPath"
         Copy-Item -Path $DefaultConfigFilePath -Destination $ConfigPath -Force:$Force
-        Write-Verbose "Initialized config file $ConfigPath"
     }
     else {
         # just verbose output that nothing is done

--- a/src/Public/Connect-MS365.ps1
+++ b/src/Public/Connect-MS365.ps1
@@ -135,16 +135,6 @@ function Connect-MS365 {
                 Connect-SPO -SPOOrgUrl $SPOOrgUrl
                 continue
             }
-            # S4B Service
-            S4B {
-                $ServiceName = "Microsoft Skype4Business"
-                $ModuleName = "SkypeOnlineConnector"
-                $ModuleFindString = $ModuleName
-
-                Connect-S4B
-                continue
-            }
-
         }
         Write-Verbose "Create session to Service $ServiceItem ended."
     }

--- a/src/Public/Connect-MS365.ps1
+++ b/src/Public/Connect-MS365.ps1
@@ -45,8 +45,14 @@ function Connect-MS365 {
                 $ModuleName = "MSOnline"
                 $ModuleFindString = $ModuleName
 
-                Connect-MSOL
-                continue
+                if ($PSVersionTable.PSEdition -eq "Desktop") {
+                    Connect-MSOL
+                    continue
+                }
+                else {
+                    Write-Error "PowerShell module ``$ModuleName`` is not supported by PowerShell Core."
+                    continue
+                }
             }
             # Exchange Online service
             EOL {
@@ -72,6 +78,7 @@ function Connect-MS365 {
                 $ModuleName = "ExchangeOnlineManagement"
                 $ModuleFindString = $ModuleName
 
+                Write-Verbose "Using ExchangeOnlineManagement module for SCC replacement."
                 Connect-SCC
                 continue
             }
@@ -81,8 +88,14 @@ function Connect-MS365 {
                 $ModuleName = "AzureAD"
                 $ModuleFindString = $ModuleName
 
-                Connect-AAD
-                continue
+                if ($PSVersionTable.PSEdition -eq "Desktop") {
+                    Connect-AAD
+                    continue
+                }
+                else {
+                    Write-Error "PowerShell module ``$ModuleName`` is not supported by PowerShell Core."
+                    continue
+                }
             }
             # Azure
             AZ {
@@ -98,6 +111,15 @@ function Connect-MS365 {
                 $ServiceName = "SharePoint Online"
                 $ModuleName = "Microsoft.Online.SharePoint.PowerShell"
                 $ModuleFindString = $ModuleName
+
+                if ($PSVersionTable.PSEdition -eq "Desktop") {
+                    Connect-AAD
+                    continue
+                }
+                else {
+                    Write-Error "PowerShell module ``$ModuleName`` is not supported by PowerShell Core."
+                    continue
+                }
 
                 If (!($SPOOrgName)) {
                     Write-Error 'To connect to SharePoint Online you have to provide the -SPOOrgName parameter.'
@@ -124,8 +146,8 @@ function Connect-MS365 {
             }
 
         }
-        Write-Verbose "Create session to Service $ServiceItem done."
+        Write-Verbose "Create session to Service $ServiceItem ended."
     }
 
-    Write-Verbose "Connect-MS365 done."
+    Write-Verbose "Connect-MS365 ended."
 }


### PR DESCRIPTION
#33 - Adding support for PowerShell 7 / PowerShell core

* added general support for PowerShell Core edition in module manifest
* removed support for Skype4Business (S4B)
* added check switch in main to block services based on Core edition for SharePoint Online (SPO), Azure AD (AAD), MS Online (MSOL)
* some MD linting fixes
* docs and README updated
